### PR TITLE
include libraries to build acronet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,3 +5,8 @@ RUN git clone https://github.com/danmar/cppcheck.git \
   && make install SRCDIR=build CFGDIR=/usr/share/cppcheck/cfg HAVE_RULES=yes CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function" \
   && cd .. \
   && rm cppcheck -rf
+
+RUN apt-get update && apt-get install -y \
+  rsync \
+  ftplib-dev \
+  graphicsmagick-libmagick-dev-compat


### PR DESCRIPTION
Need rsync to transfer files and may as well have the needed libraries for compiler rather than pulling them in via the runner